### PR TITLE
Add remaining CLI Changes and type parameters

### DIFF
--- a/vals/cli/util.py
+++ b/vals/cli/util.py
@@ -34,3 +34,25 @@ def prompt_user_for_suite():
         idx = click.prompt("Invalid choice. Retry", type=int)
     suite_id = suites[idx]["id"]
     return suite_id
+
+
+def display_table(
+    column_headers: list[str], column_widths: list[int], rows: list[list[str]]
+):
+    header = (
+        "|"
+        + "|".join([f" {h:{w}} " for h, w in zip(column_headers, column_widths)])
+        + "|"
+    )
+    click.echo(header)
+    seperator_line = (
+        "+" + "+".join(["-" * (width + 2) for width in column_widths]) + "+"
+    )
+    click.echo(seperator_line)
+    for row in rows:
+        row_str = (
+            "| "
+            + " | ".join([f"{str(r):{w}}" for r, w in zip(row, column_widths)])
+            + " |"
+        )
+        click.echo(row_str)

--- a/vals/graphql/runs/mutations.graphql
+++ b/vals/graphql/runs/mutations.graphql
@@ -1,12 +1,12 @@
 mutation startRun(
   $test_suite_id: String!
-  $parameters: GenericScalar!
+  $typed_parameters: ParameterInputType!
   $qa_set_id: String = null
   $run_name: String = null
 ) {
   startRun(
     testSuiteId: $test_suite_id
-    parameters: $parameters
+    typedParameters: $typed_parameters
     qaSetId: $qa_set_id
     runName: $run_name
   ) {

--- a/vals/graphql/runs/queries.graphql
+++ b/vals/graphql/runs/queries.graphql
@@ -37,10 +37,16 @@ query PullRun($runId: String!) {
   }
 }
 
-query ListRuns($archived: Boolean, $suiteId: String) {
-  runs(archived: $archived, suiteId: $suiteId) {
+query ListRuns(
+  $archived: Boolean
+  $suiteId: String
+  $limit: Int
+  $offset: Int
+) {
+  runs(archived: $archived, suiteId: $suiteId, limit: $limit, offset: $offset) {
     runId
     passPercentage
+    name
     status
     textSummary
     timestamp

--- a/vals/graphql_client/client.py
+++ b/vals/graphql_client/client.py
@@ -14,7 +14,11 @@ from .get_operators import GetOperators
 from .get_test_data import GetTestData
 from .get_test_suite_data import GetTestSuiteData
 from .get_test_suites_with_count import GetTestSuitesWithCount
-from .input_types import QuestionAnswerPairInputType, TestMutationInfo
+from .input_types import (
+    ParameterInputType,
+    QuestionAnswerPairInputType,
+    TestMutationInfo,
+)
 from .list_runs import ListRuns
 from .pull_run import PullRun
 from .remove_old_tests import RemoveOldTests
@@ -104,17 +108,17 @@ class Client(AsyncBaseClient):
     async def start_run(
         self,
         test_suite_id: str,
-        parameters: Any,
+        typed_parameters: ParameterInputType,
         qa_set_id: Union[Optional[str], UnsetType] = UNSET,
         run_name: Union[Optional[str], UnsetType] = UNSET,
         **kwargs: Any
     ) -> StartRun:
         query = gql(
             """
-            mutation startRun($test_suite_id: String!, $parameters: GenericScalar!, $qa_set_id: String = null, $run_name: String = null) {
+            mutation startRun($test_suite_id: String!, $typed_parameters: ParameterInputType!, $qa_set_id: String = null, $run_name: String = null) {
               startRun(
                 testSuiteId: $test_suite_id
-                parameters: $parameters
+                typedParameters: $typed_parameters
                 qaSetId: $qa_set_id
                 runName: $run_name
               ) {
@@ -125,7 +129,7 @@ class Client(AsyncBaseClient):
         )
         variables: Dict[str, object] = {
             "test_suite_id": test_suite_id,
-            "parameters": parameters,
+            "typed_parameters": typed_parameters,
             "qa_set_id": qa_set_id,
             "run_name": run_name,
         }
@@ -210,14 +214,17 @@ class Client(AsyncBaseClient):
         self,
         archived: Union[Optional[bool], UnsetType] = UNSET,
         suite_id: Union[Optional[str], UnsetType] = UNSET,
+        limit: Union[Optional[int], UnsetType] = UNSET,
+        offset: Union[Optional[int], UnsetType] = UNSET,
         **kwargs: Any
     ) -> ListRuns:
         query = gql(
             """
-            query ListRuns($archived: Boolean, $suiteId: String) {
-              runs(archived: $archived, suiteId: $suiteId) {
+            query ListRuns($archived: Boolean, $suiteId: String, $limit: Int, $offset: Int) {
+              runs(archived: $archived, suiteId: $suiteId, limit: $limit, offset: $offset) {
                 runId
                 passPercentage
+                name
                 status
                 textSummary
                 timestamp
@@ -231,7 +238,12 @@ class Client(AsyncBaseClient):
             }
             """
         )
-        variables: Dict[str, object] = {"archived": archived, "suiteId": suite_id}
+        variables: Dict[str, object] = {
+            "archived": archived,
+            "suiteId": suite_id,
+            "limit": limit,
+            "offset": offset,
+        }
         response = await self.execute(
             query=query, operation_name="ListRuns", variables=variables, **kwargs
         )

--- a/vals/graphql_client/list_runs.py
+++ b/vals/graphql_client/list_runs.py
@@ -16,6 +16,7 @@ class ListRuns(BaseModel):
 class ListRunsRuns(BaseModel):
     run_id: str = Field(alias="runId")
     pass_percentage: Optional[float] = Field(alias="passPercentage")
+    name: str
     status: str
     text_summary: str = Field(alias="textSummary")
     timestamp: datetime


### PR DESCRIPTION
- Implement `vals suite run`, `vals run pull`, `vals run list`. 
- As part of the above, added the method to list runs 
- Added limit and offset to suite list runs
- Added suite to csv
- Made parameters a type in `Suite.run()` rather than dict, and used the typed API rather than the untyped API. 