### PR TITLE
SDK Bug fixes

### DIFF
--- a/examples/example_suites/example_suite_with_everything.json
+++ b/examples/example_suites/example_suite_with_everything.json
@@ -1,0 +1,41 @@
+{
+  "title": "[VALS]: Sample Test Suite",
+  "description": "This is a test suite that uses all the features",
+  "tests": [
+    {
+      "input_under_test": "What is QSBS",
+      "golden_output": "C Corporation",
+      "context": { "foo": "bar", "baz": ["a", "b", "c"] },
+      "files_under_test": ["examples/data_files/postmoney_safe.docx"],
+      "global_checks": [
+        {
+          "operator": "grammar"
+        }
+      ],
+      "tags": ["legal", "finance"],
+      "checks": [
+        {
+          "operator": "includes",
+          "criteria": "C Corporation",
+          "modifiers": {
+            "extractor": "Extract proper nouns",
+            "conditional": { "operator": "grammar" },
+            "optional": true,
+            "severity": -1,
+            "examples": [
+              {
+                "text": "What is QSBS",
+                "type": "positive"
+              }
+            ],
+            "category": "Legal"
+          }
+        },
+        {
+          "operator": "excludes",
+          "criteria": "S Corporation"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/v2/run_examples.py
+++ b/examples/v2/run_examples.py
@@ -48,7 +48,7 @@ async def run_with_function():
         return input_under_test + "!!!"
 
     run = await suite.run(
-        model=function, wait_for_completion=True, model_name="test-model"
+        model=function, wait_for_completion=True, model_name="my_function_model"
     )
 
     print(f"Run URL: {run.url}")
@@ -83,7 +83,7 @@ async def run_with_function_context_and_files():
         return input_under_test
 
     run = await suite.run(
-        model=function, wait_for_completion=True, model_name="blah blah"
+        model=function, wait_for_completion=True, model_name="my_function_model_v2"
     )
 
     print(f"Run URL: {run.url}")

--- a/examples/v2/run_examples.py
+++ b/examples/v2/run_examples.py
@@ -27,7 +27,7 @@ async def run_with_model_under_test():
     print(f"Pass percentage: {run.pass_percentage}")
 
     # Can save the results to a CSV file.
-    run.to_csv("out.csv")
+    await run.to_csv("out.csv")
 
 
 async def run_with_function():
@@ -47,7 +47,9 @@ async def run_with_function():
         # This would be replaced with your custom model.
         return input_under_test + "!!!"
 
-    run = await suite.run(model=function, wait_for_completion=True)
+    run = await suite.run(
+        model=function, wait_for_completion=True, model_name="test-model"
+    )
 
     print(f"Run URL: {run.url}")
     print(f"Pass percentage: {run.pass_percentage}")
@@ -80,7 +82,9 @@ async def run_with_function_context_and_files():
         # to return a response.
         return input_under_test
 
-    run = await suite.run(model=function, wait_for_completion=True)
+    run = await suite.run(
+        model=function, wait_for_completion=True, model_name="blah blah"
+    )
 
     print(f"Run URL: {run.url}")
     print(f"Pass percentage: {run.pass_percentage}")
@@ -158,7 +162,7 @@ async def all():
     await run_with_function_context_and_files()
     await run_with_qa_pairs()
     await run_with_qa_pairs_and_context()
-    await pull_run("19dc86c6-774e-4946-99f4-01ad1bcf4ccf")
+    #   await pull_run("19dc86c6-774e-4946-99f4-01ad1bcf4ccf")
 
 
 if __name__ == "__main__":

--- a/examples/v2/suite_examples.py
+++ b/examples/v2/suite_examples.py
@@ -140,13 +140,6 @@ async def move_test_between_suites():
     print(f"Suite 1: {suite1.url}")
     print(f"Suite 2: {suite2.url}")
 
-    suite1.tests.append(suite2.tests[0])
-    await suite1.update()
-    await suite1.create(force_creation=True)
-
-    print(f"Suite 1: {suite1.url}")
-    print(f"Suite 2: {suite2.url}")
-
 
 async def all():
     await list_suites()

--- a/examples/v2/suite_examples.py
+++ b/examples/v2/suite_examples.py
@@ -113,6 +113,41 @@ async def load_from_json():
     print(f"Loaded from JSON: {suite}")
 
 
+async def move_test_between_suites():
+    suite1 = Suite(
+        title="Suite 1",
+        tests=[
+            Test(
+                input_under_test="What is QSBS?",
+                checks=[Check(operator="equals", criteria="QSBS")],
+            )
+        ],
+    )
+    await suite1.create()
+
+    suite2 = Suite(
+        title="Suite 2",
+        tests=[
+            Test(
+                input_under_test="What is an 83 election?",
+                checks=[Check(operator="equals", criteria="QSBS")],
+            ),
+            suite1.tests[0],
+        ],
+    )
+    await suite2.create()
+
+    print(f"Suite 1: {suite1.url}")
+    print(f"Suite 2: {suite2.url}")
+
+    suite1.tests.append(suite2.tests[0])
+    await suite1.update()
+    await suite1.create(force_creation=True)
+
+    print(f"Suite 1: {suite1.url}")
+    print(f"Suite 2: {suite2.url}")
+
+
 async def all():
     await list_suites()
     await create_suite()
@@ -121,6 +156,7 @@ async def all():
     await update_suite()
     await pull_suite()
     await load_from_json()
+    await move_test_between_suites()
 
 
 if __name__ == "__main__":

--- a/vals/cli/run.py
+++ b/vals/cli/run.py
@@ -48,7 +48,7 @@ async def list_async(
 
     column_names = ["Run Name", "Id", "Status", "Pass Rate", "Timestamp"]
     run_name_width = 40
-    column_widths = [run_name_width, 36, 13, 8, 20]
+    column_widths = [run_name_width, 36, 13, 10, 20]
 
     rows = []
     for run in run_results:

--- a/vals/cli/run.py
+++ b/vals/cli/run.py
@@ -77,7 +77,9 @@ async def list_async(
     default=25,
     help="Limit the number of runs to display",
 )
-@click.option("-o", "--offset", required=False, help="Filter runs by suite id")
+@click.option(
+    "-o", "--offset", required=False, default=0, help="Filter runs by suite id"
+)
 @click.option("--suite-id", required=False, help="Filter runs by suite id")
 @click.option(
     "--show-archived",

--- a/vals/graphql/runs/queries.graphql
+++ b/vals/graphql/runs/queries.graphql
@@ -63,38 +63,48 @@ query ListRuns(
   $limit: Int
   $offset: Int
 ) {
-  runs(archived: $archived, suiteId: $suiteId, limit: $limit, offset: $offset) {
-    runId
-    passPercentage
-    passRate {
-      value
-      error
+  runsWithCount(
+    filterOptions: {
+      archived: $archived
+      suiteId: $suiteId
+      limit: $limit
+      offset: $offset
+      sortBy: STARTED_AT
     }
-    successRate {
-      value
-      error
-    }
-    name
-    status
-    textSummary
-    timestamp
-    completedAt
-    archived
-    typedParameters {
-      evalModel
-      maximumThreads
-      runGoldenEval
-      runConfidenceEvaluation
-      heavyweightFactor
-      createTextSummary
-      modelUnderTest
-      temperature
-      maxOutputTokens
-      systemPrompt
-      newLineStopOption
-    }
-    testSuite {
-      title
+  ) {
+    runResults {
+      runId
+      passPercentage
+      passRate {
+        value
+        error
+      }
+      successRate {
+        value
+        error
+      }
+      name
+      status
+      textSummary
+      timestamp
+      completedAt
+      archived
+      typedParameters {
+        evalModel
+        maximumThreads
+        runGoldenEval
+        runConfidenceEvaluation
+        heavyweightFactor
+        createTextSummary
+        modelUnderTest
+        temperature
+        maxOutputTokens
+        systemPrompt
+        newLineStopOption
+      }
+      testSuite {
+        title
+      }
     }
   }
 }

--- a/vals/graphql/runs/queries.graphql
+++ b/vals/graphql/runs/queries.graphql
@@ -17,7 +17,19 @@ query PullRun($runId: String!) {
     timestamp
     completedAt
     archived
-    parameters
+    typedParameters {
+      evalModel
+      maximumThreads
+      runGoldenEval
+      runConfidenceEvaluation
+      heavyweightFactor
+      createTextSummary
+      modelUnderTest
+      temperature
+      maxOutputTokens
+      systemPrompt
+      newLineStopOption
+    }
     passRate {
       value
       error
@@ -68,7 +80,19 @@ query ListRuns(
     timestamp
     completedAt
     archived
-    parameters
+    typedParameters {
+      evalModel
+      maximumThreads
+      runGoldenEval
+      runConfidenceEvaluation
+      heavyweightFactor
+      createTextSummary
+      modelUnderTest
+      temperature
+      maxOutputTokens
+      systemPrompt
+      newLineStopOption
+    }
     testSuite {
       title
     }

--- a/vals/graphql/runs/queries.graphql
+++ b/vals/graphql/runs/queries.graphql
@@ -39,6 +39,7 @@ query PullRun($runId: String!) {
       error
     }
     testSuite {
+      id
       title
     }
   }

--- a/vals/graphql/suites/mutations.graphql
+++ b/vals/graphql/suites/mutations.graphql
@@ -28,6 +28,9 @@ mutation addBatchTests($tests: [TestMutationInfo!]!, $createOnly: Boolean!) {
       tags
       context
       goldenOutput
+      testSuite {
+        id
+      }
     }
   }
 }

--- a/vals/graphql/suites/queries.graphql
+++ b/vals/graphql/suites/queries.graphql
@@ -19,6 +19,9 @@ query getTestData($suiteId: String!) {
     tags
     context
     goldenOutput
+    testSuite {
+      id
+    }
   }
 }
 

--- a/vals/graphql_client/__init__.py
+++ b/vals/graphql_client/__init__.py
@@ -27,7 +27,6 @@ from .create_question_answer_set import (
 from .delete_test_suite import DeleteTestSuite, DeleteTestSuiteDeleteSuite
 from .enums import (
     AppQuestionAnswerSetCreationMethodChoices,
-    AppQuestionAnswerSetStatusChoices,
     RunResultSortField,
     RunStatus,
     SortOrder,
@@ -66,11 +65,12 @@ from .input_types import (
 )
 from .list_runs import (
     ListRuns,
-    ListRunsRuns,
-    ListRunsRunsPassRate,
-    ListRunsRunsSuccessRate,
-    ListRunsRunsTestSuite,
-    ListRunsRunsTypedParameters,
+    ListRunsRunsWithCount,
+    ListRunsRunsWithCountRunResults,
+    ListRunsRunsWithCountRunResultsPassRate,
+    ListRunsRunsWithCountRunResultsSuccessRate,
+    ListRunsRunsWithCountRunResultsTestSuite,
+    ListRunsRunsWithCountRunResultsTypedParameters,
 )
 from .pull_run import (
     PullRun,
@@ -97,7 +97,6 @@ __all__ = [
     "AddBatchTestsBatchUpdateTestTests",
     "AddBatchTestsBatchUpdateTestTestsTestSuite",
     "AppQuestionAnswerSetCreationMethodChoices",
-    "AppQuestionAnswerSetStatusChoices",
     "AsyncBaseClient",
     "BaseModel",
     "BatchAddQuestionAnswerPairs",
@@ -135,11 +134,12 @@ __all__ = [
     "GraphQLClientHttpError",
     "GraphQLClientInvalidResponseError",
     "ListRuns",
-    "ListRunsRuns",
-    "ListRunsRunsPassRate",
-    "ListRunsRunsSuccessRate",
-    "ListRunsRunsTestSuite",
-    "ListRunsRunsTypedParameters",
+    "ListRunsRunsWithCount",
+    "ListRunsRunsWithCountRunResults",
+    "ListRunsRunsWithCountRunResultsPassRate",
+    "ListRunsRunsWithCountRunResultsSuccessRate",
+    "ListRunsRunsWithCountRunResultsTestSuite",
+    "ListRunsRunsWithCountRunResultsTypedParameters",
     "MetadataType",
     "ParameterInputType",
     "PerCheckHumanReviewInputType",

--- a/vals/graphql_client/__init__.py
+++ b/vals/graphql_client/__init__.py
@@ -4,6 +4,7 @@ from .add_batch_tests import (
     AddBatchTests,
     AddBatchTestsBatchUpdateTest,
     AddBatchTestsBatchUpdateTestTests,
+    AddBatchTestsBatchUpdateTestTestsTestSuite,
 )
 from .async_base_client import AsyncBaseClient
 from .base_model import BaseModel, Upload
@@ -41,7 +42,7 @@ from .exceptions import (
     GraphQLClientInvalidResponseError,
 )
 from .get_operators import GetOperators, GetOperatorsOperators
-from .get_test_data import GetTestData, GetTestDataTests
+from .get_test_data import GetTestData, GetTestDataTests, GetTestDataTestsTestSuite
 from .get_test_suite_data import GetTestSuiteData, GetTestSuiteDataTestSuites
 from .get_test_suites_with_count import (
     GetTestSuitesWithCount,
@@ -69,6 +70,7 @@ from .list_runs import (
     ListRunsRunsPassRate,
     ListRunsRunsSuccessRate,
     ListRunsRunsTestSuite,
+    ListRunsRunsTypedParameters,
 )
 from .pull_run import (
     PullRun,
@@ -76,6 +78,7 @@ from .pull_run import (
     PullRunRunPassRate,
     PullRunRunSuccessRate,
     PullRunRunTestSuite,
+    PullRunRunTypedParameters,
     PullRunTestResults,
     PullRunTestResultsTest,
 )
@@ -92,6 +95,7 @@ __all__ = [
     "AddBatchTests",
     "AddBatchTestsBatchUpdateTest",
     "AddBatchTestsBatchUpdateTestTests",
+    "AddBatchTestsBatchUpdateTestTestsTestSuite",
     "AppQuestionAnswerSetCreationMethodChoices",
     "AppQuestionAnswerSetStatusChoices",
     "AsyncBaseClient",
@@ -118,6 +122,7 @@ __all__ = [
     "GetOperatorsOperators",
     "GetTestData",
     "GetTestDataTests",
+    "GetTestDataTestsTestSuite",
     "GetTestSuiteData",
     "GetTestSuiteDataTestSuites",
     "GetTestSuitesWithCount",
@@ -134,6 +139,7 @@ __all__ = [
     "ListRunsRunsPassRate",
     "ListRunsRunsSuccessRate",
     "ListRunsRunsTestSuite",
+    "ListRunsRunsTypedParameters",
     "MetadataType",
     "ParameterInputType",
     "PerCheckHumanReviewInputType",
@@ -142,6 +148,7 @@ __all__ = [
     "PullRunRunPassRate",
     "PullRunRunSuccessRate",
     "PullRunRunTestSuite",
+    "PullRunRunTypedParameters",
     "PullRunTestResults",
     "PullRunTestResultsTest",
     "QuestionAnswerPairInputType",

--- a/vals/graphql_client/add_batch_tests.py
+++ b/vals/graphql_client/add_batch_tests.py
@@ -27,7 +27,13 @@ class AddBatchTestsBatchUpdateTestTests(BaseModel):
     tags: Any
     context: Any
     golden_output: str = Field(alias="goldenOutput")
+    test_suite: "AddBatchTestsBatchUpdateTestTestsTestSuite" = Field(alias="testSuite")
+
+
+class AddBatchTestsBatchUpdateTestTestsTestSuite(BaseModel):
+    id: str
 
 
 AddBatchTests.model_rebuild()
 AddBatchTestsBatchUpdateTest.model_rebuild()
+AddBatchTestsBatchUpdateTestTests.model_rebuild()

--- a/vals/graphql_client/client.py
+++ b/vals/graphql_client/client.py
@@ -242,38 +242,42 @@ class Client(AsyncBaseClient):
         query = gql(
             """
             query ListRuns($archived: Boolean, $suiteId: String, $limit: Int, $offset: Int) {
-              runs(archived: $archived, suiteId: $suiteId, limit: $limit, offset: $offset) {
-                runId
-                passPercentage
-                passRate {
-                  value
-                  error
-                }
-                successRate {
-                  value
-                  error
-                }
-                name
-                status
-                textSummary
-                timestamp
-                completedAt
-                archived
-                typedParameters {
-                  evalModel
-                  maximumThreads
-                  runGoldenEval
-                  runConfidenceEvaluation
-                  heavyweightFactor
-                  createTextSummary
-                  modelUnderTest
-                  temperature
-                  maxOutputTokens
-                  systemPrompt
-                  newLineStopOption
-                }
-                testSuite {
-                  title
+              runsWithCount(
+                filterOptions: {archived: $archived, suiteId: $suiteId, limit: $limit, offset: $offset, sortBy: STARTED_AT}
+              ) {
+                runResults {
+                  runId
+                  passPercentage
+                  passRate {
+                    value
+                    error
+                  }
+                  successRate {
+                    value
+                    error
+                  }
+                  name
+                  status
+                  textSummary
+                  timestamp
+                  completedAt
+                  archived
+                  typedParameters {
+                    evalModel
+                    maximumThreads
+                    runGoldenEval
+                    runConfidenceEvaluation
+                    heavyweightFactor
+                    createTextSummary
+                    modelUnderTest
+                    temperature
+                    maxOutputTokens
+                    systemPrompt
+                    newLineStopOption
+                  }
+                  testSuite {
+                    title
+                  }
                 }
               }
             }

--- a/vals/graphql_client/client.py
+++ b/vals/graphql_client/client.py
@@ -206,6 +206,7 @@ class Client(AsyncBaseClient):
                   error
                 }
                 testSuite {
+                  id
                   title
                 }
               }

--- a/vals/graphql_client/client.py
+++ b/vals/graphql_client/client.py
@@ -184,7 +184,19 @@ class Client(AsyncBaseClient):
                 timestamp
                 completedAt
                 archived
-                parameters
+                typedParameters {
+                  evalModel
+                  maximumThreads
+                  runGoldenEval
+                  runConfidenceEvaluation
+                  heavyweightFactor
+                  createTextSummary
+                  modelUnderTest
+                  temperature
+                  maxOutputTokens
+                  systemPrompt
+                  newLineStopOption
+                }
                 passRate {
                   value
                   error
@@ -247,7 +259,19 @@ class Client(AsyncBaseClient):
                 timestamp
                 completedAt
                 archived
-                parameters
+                typedParameters {
+                  evalModel
+                  maximumThreads
+                  runGoldenEval
+                  runConfidenceEvaluation
+                  heavyweightFactor
+                  createTextSummary
+                  modelUnderTest
+                  temperature
+                  maxOutputTokens
+                  systemPrompt
+                  newLineStopOption
+                }
                 testSuite {
                   title
                 }
@@ -318,6 +342,9 @@ class Client(AsyncBaseClient):
                   tags
                   context
                   goldenOutput
+                  testSuite {
+                    id
+                  }
                 }
               }
             }
@@ -433,6 +460,9 @@ class Client(AsyncBaseClient):
                 tags
                 context
                 goldenOutput
+                testSuite {
+                  id
+                }
               }
             }
             """

--- a/vals/graphql_client/enums.py
+++ b/vals/graphql_client/enums.py
@@ -10,7 +10,7 @@ class AppQuestionAnswerSetCreationMethodChoices(str, Enum):
     UPLOAD = "UPLOAD"
 
 
-class AppQuestionAnswerSetStatusChoices(str, Enum):
+class RunStatus(str, Enum):
     IN_PROGRESS = "IN_PROGRESS"
     ERROR = "ERROR"
     SUCCESS = "SUCCESS"
@@ -25,12 +25,6 @@ class TestSuiteSortField(str, Enum):
 class SortOrder(str, Enum):
     ASC = "ASC"
     DESC = "DESC"
-
-
-class RunStatus(str, Enum):
-    IN_PROGRESS = "IN_PROGRESS"
-    ERROR = "ERROR"
-    SUCCESS = "SUCCESS"
 
 
 class RunResultSortField(str, Enum):

--- a/vals/graphql_client/get_test_data.py
+++ b/vals/graphql_client/get_test_data.py
@@ -21,6 +21,12 @@ class GetTestDataTests(BaseModel):
     tags: Any
     context: Any
     golden_output: str = Field(alias="goldenOutput")
+    test_suite: "GetTestDataTestsTestSuite" = Field(alias="testSuite")
+
+
+class GetTestDataTestsTestSuite(BaseModel):
+    id: str
 
 
 GetTestData.model_rebuild()
+GetTestDataTests.model_rebuild()

--- a/vals/graphql_client/input_types.py
+++ b/vals/graphql_client/input_types.py
@@ -36,8 +36,8 @@ class RunResultFilterOptionsInput(BaseModel):
 
 class CheckInputType(BaseModel):
     operator: str
-    criteria: str
-    modifiers: "CheckModifiersInputType"
+    criteria: Optional[str] = None
+    modifiers: Optional["CheckModifiersInputType"] = None
 
 
 class CheckModifiersInputType(BaseModel):

--- a/vals/graphql_client/input_types.py
+++ b/vals/graphql_client/input_types.py
@@ -100,6 +100,7 @@ class QuestionAnswerPairInputType(BaseModel):
     input_under_test: str = Field(alias="inputUnderTest")
     file_ids: Optional[List[Optional[str]]] = Field(alias="fileIds", default=None)
     context: Optional[Any] = None
+    output_context: Optional[Any] = Field(alias="outputContext", default=None)
     llm_output: str = Field(alias="llmOutput")
     metadata: Optional["MetadataType"] = None
     test_id: Optional[str] = Field(alias="testId", default=None)

--- a/vals/graphql_client/list_runs.py
+++ b/vals/graphql_client/list_runs.py
@@ -10,35 +10,45 @@ from .base_model import BaseModel
 
 
 class ListRuns(BaseModel):
-    runs: List["ListRunsRuns"]
+    runs_with_count: "ListRunsRunsWithCount" = Field(alias="runsWithCount")
 
 
-class ListRunsRuns(BaseModel):
+class ListRunsRunsWithCount(BaseModel):
+    run_results: List["ListRunsRunsWithCountRunResults"] = Field(alias="runResults")
+
+
+class ListRunsRunsWithCountRunResults(BaseModel):
     run_id: str = Field(alias="runId")
     pass_percentage: Optional[float] = Field(alias="passPercentage")
-    pass_rate: Optional["ListRunsRunsPassRate"] = Field(alias="passRate")
-    success_rate: Optional["ListRunsRunsSuccessRate"] = Field(alias="successRate")
+    pass_rate: Optional["ListRunsRunsWithCountRunResultsPassRate"] = Field(
+        alias="passRate"
+    )
+    success_rate: Optional["ListRunsRunsWithCountRunResultsSuccessRate"] = Field(
+        alias="successRate"
+    )
     name: str
     status: str
     text_summary: str = Field(alias="textSummary")
     timestamp: datetime
     completed_at: Optional[datetime] = Field(alias="completedAt")
     archived: bool
-    typed_parameters: "ListRunsRunsTypedParameters" = Field(alias="typedParameters")
-    test_suite: "ListRunsRunsTestSuite" = Field(alias="testSuite")
+    typed_parameters: "ListRunsRunsWithCountRunResultsTypedParameters" = Field(
+        alias="typedParameters"
+    )
+    test_suite: "ListRunsRunsWithCountRunResultsTestSuite" = Field(alias="testSuite")
 
 
-class ListRunsRunsPassRate(BaseModel):
+class ListRunsRunsWithCountRunResultsPassRate(BaseModel):
     value: float
     error: float
 
 
-class ListRunsRunsSuccessRate(BaseModel):
+class ListRunsRunsWithCountRunResultsSuccessRate(BaseModel):
     value: float
     error: float
 
 
-class ListRunsRunsTypedParameters(BaseModel):
+class ListRunsRunsWithCountRunResultsTypedParameters(BaseModel):
     eval_model: str = Field(alias="evalModel")
     maximum_threads: int = Field(alias="maximumThreads")
     run_golden_eval: bool = Field(alias="runGoldenEval")
@@ -52,9 +62,10 @@ class ListRunsRunsTypedParameters(BaseModel):
     new_line_stop_option: bool = Field(alias="newLineStopOption")
 
 
-class ListRunsRunsTestSuite(BaseModel):
+class ListRunsRunsWithCountRunResultsTestSuite(BaseModel):
     title: str
 
 
 ListRuns.model_rebuild()
-ListRunsRuns.model_rebuild()
+ListRunsRunsWithCount.model_rebuild()
+ListRunsRunsWithCountRunResults.model_rebuild()

--- a/vals/graphql_client/list_runs.py
+++ b/vals/graphql_client/list_runs.py
@@ -2,7 +2,7 @@
 # Source: vals/graphql/
 
 from datetime import datetime
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from pydantic import Field
 
@@ -24,7 +24,7 @@ class ListRunsRuns(BaseModel):
     timestamp: datetime
     completed_at: Optional[datetime] = Field(alias="completedAt")
     archived: bool
-    parameters: Any
+    typed_parameters: "ListRunsRunsTypedParameters" = Field(alias="typedParameters")
     test_suite: "ListRunsRunsTestSuite" = Field(alias="testSuite")
 
 
@@ -36,6 +36,20 @@ class ListRunsRunsPassRate(BaseModel):
 class ListRunsRunsSuccessRate(BaseModel):
     value: float
     error: float
+
+
+class ListRunsRunsTypedParameters(BaseModel):
+    eval_model: str = Field(alias="evalModel")
+    maximum_threads: int = Field(alias="maximumThreads")
+    run_golden_eval: bool = Field(alias="runGoldenEval")
+    run_confidence_evaluation: bool = Field(alias="runConfidenceEvaluation")
+    heavyweight_factor: int = Field(alias="heavyweightFactor")
+    create_text_summary: bool = Field(alias="createTextSummary")
+    model_under_test: str = Field(alias="modelUnderTest")
+    temperature: float
+    max_output_tokens: int = Field(alias="maxOutputTokens")
+    system_prompt: str = Field(alias="systemPrompt")
+    new_line_stop_option: bool = Field(alias="newLineStopOption")
 
 
 class ListRunsRunsTestSuite(BaseModel):

--- a/vals/graphql_client/pull_run.py
+++ b/vals/graphql_client/pull_run.py
@@ -53,6 +53,7 @@ class PullRunRunSuccessRate(BaseModel):
 
 
 class PullRunRunTestSuite(BaseModel):
+    id: str
     title: str
 
 

--- a/vals/graphql_client/pull_run.py
+++ b/vals/graphql_client/pull_run.py
@@ -22,10 +22,24 @@ class PullRunRun(BaseModel):
     timestamp: datetime
     completed_at: Optional[datetime] = Field(alias="completedAt")
     archived: bool
-    parameters: Any
+    typed_parameters: "PullRunRunTypedParameters" = Field(alias="typedParameters")
     pass_rate: Optional["PullRunRunPassRate"] = Field(alias="passRate")
     success_rate: Optional["PullRunRunSuccessRate"] = Field(alias="successRate")
     test_suite: "PullRunRunTestSuite" = Field(alias="testSuite")
+
+
+class PullRunRunTypedParameters(BaseModel):
+    eval_model: str = Field(alias="evalModel")
+    maximum_threads: int = Field(alias="maximumThreads")
+    run_golden_eval: bool = Field(alias="runGoldenEval")
+    run_confidence_evaluation: bool = Field(alias="runConfidenceEvaluation")
+    heavyweight_factor: int = Field(alias="heavyweightFactor")
+    create_text_summary: bool = Field(alias="createTextSummary")
+    model_under_test: str = Field(alias="modelUnderTest")
+    temperature: float
+    max_output_tokens: int = Field(alias="maxOutputTokens")
+    system_prompt: str = Field(alias="systemPrompt")
+    new_line_stop_option: bool = Field(alias="newLineStopOption")
 
 
 class PullRunRunPassRate(BaseModel):

--- a/vals/sdk/v2/run.py
+++ b/vals/sdk/v2/run.py
@@ -121,7 +121,9 @@ class Run(BaseModel):
         result = await client.list_runs(
             limit=limit, offset=offset, suite_id=suite_id, archived=show_archived
         )
-        return [RunMetadata.from_graphql(run) for run in result.runs]
+        return [
+            RunMetadata.from_graphql(run) for run in result.runs_with_count.run_results
+        ]
 
     @classmethod
     async def from_id(cls, run_id: str) -> "Run":

--- a/vals/sdk/v2/run.py
+++ b/vals/sdk/v2/run.py
@@ -105,7 +105,7 @@ class Run(BaseModel):
                 for test_result in result.test_results
             ],
             test_suite_title=result.run.test_suite.title,
-            test_suite_id=result.run.test_suite.title,
+            test_suite_id=result.run.test_suite.id,
         )
 
     @classmethod

--- a/vals/sdk/v2/run.py
+++ b/vals/sdk/v2/run.py
@@ -70,7 +70,7 @@ class Run(BaseModel):
         """Helper method to create a Run instance from a pull_run query result"""
 
         # Map maximum_threads to parallelism for backwards compatibility
-        parameters_dict = json.loads(result.run.parameters)
+        parameters_dict = result.run.typed_parameters.model_dump()
         model = parameters_dict.pop("model_under_test", "")
         if "maximum_threads" in parameters_dict:
             parameters_dict["parallelism"] = parameters_dict.pop("maximum_threads")

--- a/vals/sdk/v2/suite.py
+++ b/vals/sdk/v2/suite.py
@@ -107,7 +107,7 @@ class Suite(BaseModel):
         """
 
         title = data["title"]
-        description = data["description"]
+        description = data.get("description", "")
         global_checks = [
             Check.from_graphql(check_dict)
             for check_dict in data.get("global_checks", [])
@@ -184,10 +184,16 @@ class Suite(BaseModel):
         with open(file_path, "w") as f:
             f.write(self.to_csv_string())
 
-    async def create(self) -> None:
+    async def create(self, force_creation: bool = False) -> None:
         """
         Creates the test suite on the server.
+
+        force_creation: If True, will create a new test suite, even if it
+        already exists.
         """
+        if force_creation:
+            self.id = None
+
         if self.id is not None:
             raise Exception("This suite has already been created.")
 
@@ -321,6 +327,7 @@ class Suite(BaseModel):
             )
         elif isinstance(model, list):
             # Use the QA pairs we are already provided
+            parameter_input.model_under_test = model_name
             qa_set_id = await self._create_qa_set(
                 [qa_pair.to_graphql() for qa_pair in model],
                 parameter_input.model_dump(),

--- a/vals/sdk/v2/suite.py
+++ b/vals/sdk/v2/suite.py
@@ -145,7 +145,7 @@ class Suite(BaseModel):
 
     @property
     def url(self):
-        return f"{fe_host()}/view?test_suite_id={self.id}"
+        return f"{fe_host()}/suites/{self.id}"
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/vals/sdk/v2/types.py
+++ b/vals/sdk/v2/types.py
@@ -23,7 +23,7 @@ from vals.graphql_client.input_types import (
     QuestionAnswerPairInputType,
     TestMutationInfo,
 )
-from vals.graphql_client.list_runs import ListRunsRuns
+from vals.graphql_client.list_runs import ListRunsRunsWithCountRunResults
 from vals.graphql_client.pull_run import PullRunTestResults
 from vals.sdk.v2.operator_type import OperatorType
 
@@ -288,7 +288,9 @@ class RunMetadata(BaseModel):
     parameters: RunParameters
 
     @classmethod
-    def from_graphql(cls, graphql_run: ListRunsRuns) -> "RunMetadata":
+    def from_graphql(
+        cls, graphql_run: ListRunsRunsWithCountRunResults
+    ) -> "RunMetadata":
         return cls(
             id=graphql_run.run_id,
             name=graphql_run.name,

--- a/vals/sdk/v2/types.py
+++ b/vals/sdk/v2/types.py
@@ -88,7 +88,7 @@ class ConditionalCheck(BaseModel):
     """
 
     operator: OperatorType
-    criteria: str
+    criteria: str = ""
 
 
 class CheckModifiers(BaseModel):


### PR DESCRIPTION
- Fixed a bug where pulling parameters caused an error (also switched to using typedParameters instead)
- Fixed `RunStatus` enum being incorrect 
- Allow them to move tests between test suites
- Add a flag to allow forcing a create, even if the suite is already created.  
- Fixed a bug that was breaking adding Metadata in QA Pairs 
- Fix bug with `vals run list` where the order wasn't consistent 
- Suite URL points to new suite page 
- Fix to allow unary operators on predicate checks
- Small change to how runs print after `vals suite run` 
- `vals run list` wasn't using suite id 
- Changed offset to be 1-indexed, because the tables we display are 1-indexed 
- `vals run pull` was setting the run's test suite id wrong 