### PR TITLE
Add Buffer time for token refresh

### DIFF
--- a/vals/sdk/auth.py
+++ b/vals/sdk/auth.py
@@ -81,7 +81,8 @@ def _get_auth_token():
 
     if (
         "access_expiry" not in global_auth_dict
-        or time.time() > global_auth_dict["access_expiry"]
+        # Refresh token 1 minute before it expires 
+        or time.time() + 60 > global_auth_dict["access_expiry"]
     ):
         descopeClient = get_descope_client()
 


### PR DESCRIPTION
The following error was reported:
```
vals.graphql_client.exceptions.GraphQLClientGraphQLMultiError: User access key is invalid: {'status_code': 400, 'error_type': 'invalid token', 'error_message': 'Received Invalid token times error due to time glitch (between machines) during jwt validation, try to set the jwt_validation_leeway parameter (in DescopeClient) to higher value than 5sec which is the default'}
```

When I've experienced this in the past, it actually means that the access token was not properly refreshed, and therefore was not valid. He also mentioned this happening at around the ten minute mark. 

I'm not sure if it will fix the root cause, but rather than refreshing the token right before the mutation is sent, I am adding a buffer of 60 seconds. If it expires within 60 seconds then we should refresh now rather than waiting. 