### PR TITLE
fix: add missing RunStatus import in GraphQL client

### DIFF
--- a/vals/graphql_client/client.py
+++ b/vals/graphql_client/client.py
@@ -13,6 +13,7 @@ from .delete_test_suite import DeleteTestSuite
 from .get_active_custom_operators import GetActiveCustomOperators
 from .get_default_parameters import GetDefaultParameters
 from .get_operators import GetOperators
+from .enums import RunStatus
 from .get_run_status import GetRunStatus
 from .get_single_run_review import GetSingleRunReview
 from .get_test_data import GetTestData


### PR DESCRIPTION
## Summary
- Add missing `RunStatus` import in `vals/graphql_client/client.py`
- The `RunStatus` type was being used in method signatures but wasn't imported
- Fixes type resolution issues in the GraphQL client

🤖 Generated with [Claude Code](https://claude.ai/code)