### PR TITLE
feat: convert SDK export methods to properly async

### DIFF
--- a/vals/sdk/run.py
+++ b/vals/sdk/run.py
@@ -195,7 +195,7 @@ class Run(BaseModel):
     def to_json_file(self, file_path: str) -> None:
         """Converts the run to a JSON file."""
         with open(file_path, "w") as f:
-            f.write(self.to_json_string())
+            f.write(await self.to_json_string())
 
     async def pull(self) -> None:
         """Update this Run instance with latest data from vals servers."""

--- a/vals/sdk/run.py
+++ b/vals/sdk/run.py
@@ -3,6 +3,7 @@ import time
 from datetime import datetime
 from typing import Any
 
+import aiohttp
 import requests
 from pydantic import BaseModel, PrivateAttr
 from vals.graphql_client import Client
@@ -192,7 +193,7 @@ class Run(BaseModel):
         """Converts the run to a dictionary."""
         return self.model_dump(exclude_none=True, exclude_defaults=True, mode="json")
 
-    def to_json_file(self, file_path: str) -> None:
+    async def to_json_file(self, file_path: str) -> None:
         """Converts the run to a JSON file."""
         with open(file_path, "w") as f:
             f.write(await self.to_json_string())
@@ -275,26 +276,26 @@ class Run(BaseModel):
 
     async def to_csv_string(self) -> str:
         """Same as to_csv, but returns a string instead of writing to a file."""
-        response = requests.post(
-            url=f"{be_host()}/export_results_to_file/?run_id={self.id}",
-            headers={"Authorization": _get_auth_token()},
-        )
-
-        if response.status_code != 200:
-            raise ValsException("Received Error from Vals Servers: " + response.text)
-
-        return response.text
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url=f"{be_host()}/export_results_to_file/?run_id={self.id}",
+                headers={"Authorization": _get_auth_token()},
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    raise ValsException("Received Error from Vals Servers: " + error_text)
+                return await response.text()
 
     async def to_json_string(self) -> str:
-        response = requests.post(
-            url=f"{be_host()}/export_run_to_json/?run_id={self.id}",
-            headers={"Authorization": _get_auth_token()},
-        )
-
-        if response.status_code != 200:
-            raise ValsException("Received Error from Vals Servers: " + response.text)
-
-        return response.text
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url=f"{be_host()}/export_run_to_json/?run_id={self.id}",
+                headers={"Authorization": _get_auth_token()},
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    raise ValsException("Received Error from Vals Servers: " + error_text)
+                return await response.text()
 
     async def to_csv(self, file_path: str) -> None:
         """Get the CSV results of a run, as bytes."""

--- a/vals/sdk/suite.py
+++ b/vals/sdk/suite.py
@@ -247,14 +247,14 @@ class Suite(BaseModel):
         """
         return self.model_dump(exclude_none=True, exclude_defaults=True)
 
-    def to_json_file(self, file_path: str) -> None:
+    async def to_json_file(self, file_path: str) -> None:
         """
         Converts the test suite to a JSON file.
         """
         with open(file_path, "w") as f:
-            f.write(self.to_json_string())
+            f.write(await self.to_json_string())
 
-    def to_csv_string(self) -> str:
+    async def to_csv_string(self) -> str:
         """
         Like to_csv_file, but returns the file as a string instead of writing it to a file.
         """
@@ -262,16 +262,17 @@ class Suite(BaseModel):
             raise Exception("Suite has not been created yet.")
 
         url = f"{be_host()}/export_tests_to_file/?suite_id={self.id}"
-        response = requests.post(
-            url,
-            headers={"Authorization": _get_auth_token()},
-        )
-        if response.status_code != 200:
-            raise Exception(f"Failed to export tests: {response.text}")
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                headers={"Authorization": _get_auth_token()},
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    raise Exception(f"Failed to export tests: {error_text}")
+                return await response.text()
 
-        return response.text
-
-    def to_json_string(self) -> str:
+    async def to_json_string(self) -> str:
         """
         Converts the test suite to a JSON string.
         """
@@ -279,22 +280,22 @@ class Suite(BaseModel):
             raise Exception("Suite has not been created yet.")
 
         url = f"{be_host()}/export_tests_to_json/?suite_id={self.id}"
-        response = requests.post(
-            url,
-            headers={"Authorization": _get_auth_token()},
-        )
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url,
+                headers={"Authorization": _get_auth_token()},
+            ) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    raise Exception(f"Failed to export tests: {error_text}")
+                return await response.text()
 
-        if response.status_code != 200:
-            raise Exception(f"Failed to export tests: {response.text}")
-
-        return response.text
-
-    def to_csv_file(self, file_path: str) -> None:
+    async def to_csv_file(self, file_path: str) -> None:
         """
         Converts the test suite to a CSV file.
         """
         with open(file_path, "w") as f:
-            f.write(self.to_csv_string())
+            f.write(await self.to_csv_string())
 
     async def create(
         self, force_creation: bool = False, max_upload_concurrency: int = 10


### PR DESCRIPTION
## Summary
- Convert all `to_csv_string`, `to_json_string`, `to_csv_file`, and `to_json_file` methods in Run and Suite classes to use proper async HTTP calls
- Replace blocking `requests.post()` calls with non-blocking `aiohttp.ClientSession()` calls
- Ensure methods don't block the event loop when called in async contexts

## Changes
- **Run class**: Fixed `to_csv_string()` and `to_json_string()` to use aiohttp instead of requests
- **Suite class**: Converted `to_csv_string()`, `to_json_string()`, `to_csv_file()`, and `to_json_file()` to async with proper aiohttp usage

## Test plan
- Verify all export methods work correctly in async contexts
- Ensure no blocking behavior when called from async code
- Test CSV and JSON export functionality for both runs and suites

🤖 Generated with [Claude Code](https://claude.ai/code)