### PR TITLE
batch sdk fix

### DIFF
--- a/vals/graphql/suites/mutations.graphql
+++ b/vals/graphql/suites/mutations.graphql
@@ -4,7 +4,7 @@ mutation createOrUpdateTestSuite(
   $testSuiteId: String!
   $title: String!
   $description: String!
-  $projectId: String
+  $projectId: String!
 ) {
   updateTestSuite(
     testSuiteId: $testSuiteId
@@ -24,8 +24,11 @@ mutation createOrUpdateTestSuite(
   }
 }
 
-mutation addBatchTests($tests: [TestMutationInfo!]!, $createOnly: Boolean!) {
-  batchUpdateTest(tests: $tests, createOnly: $createOnly) {
+mutation addBatchTests(
+  $test_info: [TestMutationInfo!]!
+  $createOnly: Boolean!
+) {
+  batchUpdateTest(tests: $test_info, createOnly: $createOnly) {
     tests {
       ...TestFragment
     }

--- a/vals/graphql/suites/queries.graphql
+++ b/vals/graphql/suites/queries.graphql
@@ -30,7 +30,7 @@ query getTestSuitesWithCount(
   $offset: Int
   $limit: Int
   $search: String
-  $projectId: String
+  $projectId: String!
 ) {
   testSuitesWithCount(
     filterOptions: {

--- a/vals/graphql_client/client.py
+++ b/vals/graphql_client/client.py
@@ -703,12 +703,12 @@ class Client(AsyncBaseClient):
         test_suite_id: str,
         title: str,
         description: str,
-        project_id: Union[Optional[str], UnsetType] = UNSET,
+        project_id: str,
         **kwargs: Any
     ) -> CreateOrUpdateTestSuite:
         query = gql(
             """
-            mutation createOrUpdateTestSuite($testSuiteId: String!, $title: String!, $description: String!, $projectId: String) {
+            mutation createOrUpdateTestSuite($testSuiteId: String!, $title: String!, $description: String!, $projectId: String!) {
               updateTestSuite(
                 testSuiteId: $testSuiteId
                 title: $title
@@ -744,12 +744,12 @@ class Client(AsyncBaseClient):
         return CreateOrUpdateTestSuite.model_validate(data)
 
     async def add_batch_tests(
-        self, tests: List[TestMutationInfo], create_only: bool, **kwargs: Any
+        self, test_info: List[TestMutationInfo], create_only: bool, **kwargs: Any
     ) -> AddBatchTests:
         query = gql(
             """
-            mutation addBatchTests($tests: [TestMutationInfo!]!, $createOnly: Boolean!) {
-              batchUpdateTest(tests: $tests, createOnly: $createOnly) {
+            mutation addBatchTests($test_info: [TestMutationInfo!]!, $createOnly: Boolean!) {
+              batchUpdateTest(tests: $test_info, createOnly: $createOnly) {
                 tests {
                   ...TestFragment
                 }
@@ -789,7 +789,10 @@ class Client(AsyncBaseClient):
             }
             """
         )
-        variables: Dict[str, object] = {"tests": tests, "createOnly": create_only}
+        variables: Dict[str, object] = {
+            "test_info": test_info,
+            "createOnly": create_only,
+        }
         response = await self.execute(
             query=query, operation_name="addBatchTests", variables=variables, **kwargs
         )
@@ -1009,15 +1012,15 @@ class Client(AsyncBaseClient):
 
     async def get_test_suites_with_count(
         self,
+        project_id: str,
         offset: Union[Optional[int], UnsetType] = UNSET,
         limit: Union[Optional[int], UnsetType] = UNSET,
         search: Union[Optional[str], UnsetType] = UNSET,
-        project_id: Union[Optional[str], UnsetType] = UNSET,
         **kwargs: Any
     ) -> GetTestSuitesWithCount:
         query = gql(
             """
-            query getTestSuitesWithCount($offset: Int, $limit: Int, $search: String, $projectId: String) {
+            query getTestSuitesWithCount($offset: Int, $limit: Int, $search: String, $projectId: String!) {
               testSuitesWithCount(
                 filterOptions: {offset: $offset, limit: $limit, search: $search, projectId: $projectId}
               ) {

--- a/vals/sdk/suite.py
+++ b/vals/sdk/suite.py
@@ -315,7 +315,7 @@ class Suite(BaseModel):
 
         # Create suite object on the server
         suite = await self._client.create_or_update_test_suite(
-            "0", self.title, self.description, project_id=self.project_id
+            "0", self.title, self.description, self.project_id or ""
         )
         if suite.update_test_suite is None:
             raise Exception("Unable to update the test suite.")
@@ -353,7 +353,7 @@ class Suite(BaseModel):
             )
 
         suite = await self._client.create_or_update_test_suite(
-            self.id, self.title, self.description
+            self.id, self.title, self.description, self.project_id or ""
         )
         self.project_id = suite.update_test_suite.test_suite.project.slug
 
@@ -832,7 +832,7 @@ class Suite(BaseModel):
             for i in range(0, len(test_mutations), 25):
                 batch = test_mutations[i : i + 25]
                 batch_result = await self._client.add_batch_tests(
-                    tests=batch,
+                    test_info=batch,
                     create_only=create_only,
                 )
                 if batch_result.batch_update_test is None:


### PR DESCRIPTION
- Changed query param to be different than the object its returning which fixed the code gen.
- Applied project id to suite create method which fixed the 400 status error
- Made project id required for some of our graphql files which reflect the resolvers